### PR TITLE
Configuration to run app behind proxy

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKER_HUB_USER }}
+        password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ./docker
+        file: ./docker/Dockerfile
+        push: true
+        tags: ${{ secrets.DOCKER_HUB_USER }}/os2borgerpc-admin-site:${{ github.ref_name }}
+
+    - name: Post build digest
+      run: echo "Docker image for release ${{ github.ref_name }} pushed to Docker Hub."

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Build and push Docker image
       uses: docker/build-push-action@v5
       with:
-        context: ./docker
+        context: ./
         file: ./docker/Dockerfile
         push: true
         tags: ${{ secrets.DOCKER_HUB_USER }}/os2borgerpc-admin-site:${{ github.ref_name }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,6 +1,7 @@
 name: Docker Image CI
 
 on:
+  workfloworkflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,7 @@
 name: Docker Image CI
 
 on:
-  workfloworkflow_dispatch:
+  workflow_dispatch:
   release:
     types: [published]
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -28,7 +28,7 @@ jobs:
         context: ./
         file: ./docker/Dockerfile
         push: true
-        tags: ${{ secrets.DOCKER_HUB_USER }}/os2borgerpc-admin-site:${{ github.ref_name }}
+        tags: kvalitetsit/os2borgerpc-admin-site:${{ github.ref_name }}
 
     - name: Post build digest
       run: echo "Docker image for release ${{ github.ref_name }} pushed to Docker Hub."

--- a/admin_site/os2borgerpc_admin/middlewares.py
+++ b/admin_site/os2borgerpc_admin/middlewares.py
@@ -19,3 +19,21 @@ class user_locale_middleware(MiddlewareMixin):
             language = translation.get_language_from_request(request)
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
+
+
+class HttpsOnlyMiddleware:
+    """
+    Override request.is_secure() to always return True.
+    
+    Only use if you're **always** serving with HTTPS
+    **and** SECURE_PROXY_SSL_HEADER is not suitable for your setup. 
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        def is_secure():
+            return True
+        request.is_secure = is_secure
+        return self.get_response(request)

--- a/admin_site/os2borgerpc_admin/settings.py
+++ b/admin_site/os2borgerpc_admin/settings.py
@@ -203,7 +203,8 @@ MIDDLEWARE = (
     "django_otp.middleware.OTPMiddleware",
     "os2borgerpc_admin.middlewares.user_locale_middleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-)
+) + (("os2borgerpc_admin.middlewares.HttpsOnlyMiddleware",) if os.getenv('HTTPS_GUARANTEED') == 'true' else ())
+
 
 # Email settings
 

--- a/admin_site/os2borgerpc_admin/settings.py
+++ b/admin_site/os2borgerpc_admin/settings.py
@@ -53,6 +53,10 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
+header = os.environ['SECURE_PROXY_SSL_HEADER']
+headerValue = os.environ['SECURE_PROXY_SSL_HEADER_VALUE']
+if header:
+    SECURE_PROXY_SSL_HEADER = (header, headerValue)
 
 # Template settings
 TEMPLATES = [

--- a/admin_site/os2borgerpc_admin/settings.py
+++ b/admin_site/os2borgerpc_admin/settings.py
@@ -83,11 +83,11 @@ SOURCE_DIR = os.path.abspath(os.path.join(install_dir, ".."))
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": settings["DB_NAME"],
-        "USER": settings["DB_USER"],
-        "PASSWORD": settings["DB_PASSWORD"],
-        "HOST": settings["DB_HOST"],
-        "PORT": settings.get("DB_PORT", fallback=""),
+        "NAME": os.environ['DB_NAME'],
+        "USER": os.environ['DB_USER'],
+        "PASSWORD": os.environ['DB_PASSWORD'],
+        "HOST": os.environ['DB_HOST'],
+        "PORT": os.environ['DB_PORT'],
         "OPTIONS": {
             "connect_timeout": 2,  # Minimum in 2
         },

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,11 @@ services:
         environment:
             UID: 75030
             GID: 75030
+            DB_HOST: db
+            DB_NAME: bpc
+            DB_USER: bpc
+            DB_PASSWORD: bpc
+            DB_PORT: ""
         user: "${UID}:${GID}"
         build:
             context: .

--- a/dev-environment/dev-settings.ini
+++ b/dev-environment/dev-settings.ini
@@ -12,12 +12,6 @@ SECRET_KEY=v3rys1kr3t
 ADMIN_NAME=OS2borgerPC Admin
 ADMIN_EMAIL=os2borgerpc_admin@os2borgerpc-vendor.example
 
-# Database
-DB_HOST=db
-DB_NAME=bpc
-DB_USER=bpc
-DB_PASSWORD=bpc
-
 # Timezone/Language
 TIME_ZONE=Europe/Copenhagen
 LANGUAGE_CODE=da-dk

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,11 @@ COPY --from=frontend \
 # set of insecure setting here for only this purpose. We make sure to delete it
 # afterward. If `insecure-settings.ini` is found in any production image,
 # consider it a bug. See `insecure-settings.ini` for a detailed explanation.
+ENV DB_NAME="dummy" \
+    DB_USER="dummy" \
+    DB_PASSWORD="dummy" \
+    DB_HOST="dummy" \
+    DB_PORT="dummy"
 RUN set -ex \
   && BPC_USER_CONFIG_PATH=/code/docker/insecure-settings.ini python ./manage.py collectstatic --no-input --clear \
   && BPC_USER_CONFIG_PATH=/code/docker/insecure-settings.ini python ./manage.py compilemessages \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,17 +33,17 @@ RUN set -ex \
   # automatic ranges of UID_MAX/GID_MAX used by useradd/groupadd. See
   # `/etc/login.defs`. Hopefully there will be no conflicts with users of the
   # host system or users of other docker containers.
-  && groupadd -g 75030 -r bpc\
-  && useradd -u 75030 --no-log-init -r -g bpc bpc \
+  # && groupadd -g 75030 -r bpc\
+  # && useradd -u 75030 --no-log-init -r -g bpc bpc \
   # Install system dependencies from file.
   && apt-get -y update \
   && apt-get -y install --no-install-recommends $(grep -o '^[^#][[:alnum:].-]*' sys-requirements.txt) \
   # clean up after apt-get and man-pages
   && apt-get clean \
   && rm -rf "/var/lib/apt/lists/*"  "/tmp/*"  "/var/tmp/*"  "/usr/share/man/??"  "/usr/share/man/??_*" \
- # create folders at easily mountable paths for output from django
- && install -o bpc -g bpc -d /log \
- && install -o bpc -g bpc -d /media
+#  # create folders at easily mountable paths for output from django
+#  && install -o bpc -g bpc -d /log \
+#  && install -o bpc -g bpc -d /media
 
 VOLUME /log
 VOLUME /media
@@ -102,7 +102,7 @@ RUN set -ex \
   && rm /code/docker/insecure-settings.ini
 
 # Run the server as the bpc user on port 9999
-USER bpc:bpc
+USER 1001
 EXPOSE 9999
 ENTRYPOINT ["/code/docker/docker-entrypoint.sh"]
 CMD ["gunicorn", \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -98,7 +98,9 @@ ENV DB_NAME="dummy" \
     DB_USER="dummy" \
     DB_PASSWORD="dummy" \
     DB_HOST="dummy" \
-    DB_PORT="dummy"
+    DB_PORT="dummy" \
+    SECURE_PROXY_SSL_HEADER="dummy" \
+    SECURE_PROXY_SSL_HEADER_VALUE="dummy"
 RUN set -ex \
   && BPC_USER_CONFIG_PATH=/code/docker/insecure-settings.ini python ./manage.py collectstatic --no-input --clear \
   && BPC_USER_CONFIG_PATH=/code/docker/insecure-settings.ini python ./manage.py compilemessages \


### PR DESCRIPTION
Add configuration to trust requests behind proxy

This adds an option that causes Django to trust all requests.
This is useful for cases where the admin-site is running behind a proxy that terminates TLS (such as nginx), thus causing Django to only receive a HTTP (as opposed to HTTPS) request, despite the request originally being HTTPS.
When this option is enabled, HTTP request are treated the same as HTTPS, which they effectively are when running behind a TLS-terminating proxy.