### PR TITLE
Fix error if no scripts are present

### DIFF
--- a/admin_site/system/views.py
+++ b/admin_site/system/views.py
@@ -1128,7 +1128,8 @@ class ScriptMixin(object):
         global_scripts = scripts.filter(site=None)
         context["global_scripts"] = global_scripts
 
-        context["supported_products"] = self.script.products.all()
+        if self.script:
+            context["supported_products"] = self.script.products.all()
 
         # Create a tag->scripts dict for tags that has local scripts.
         local_tag_scripts_dict = {


### PR DESCRIPTION
Fix scripts tab crashing when there are no scripts

If there are no scripts present, the script view now shows a page where the first script can be added, instead of showing an error.
