### PR TITLE
Configuration to run behind proxy

### DIFF
--- a/admin_site/os2borgerpc_admin/middlewares.py
+++ b/admin_site/os2borgerpc_admin/middlewares.py
@@ -19,3 +19,20 @@ class user_locale_middleware(MiddlewareMixin):
             language = translation.get_language_from_request(request)
         translation.activate(language)
         request.LANGUAGE_CODE = translation.get_language()
+
+class HttpsOnlyMiddleware:
+    """
+    Override request.is_secure() to always return True.
+    
+    Only use if you're **always** serving with HTTPS
+    **and** SECURE_PROXY_SSL_HEADER is not suitable for your setup. 
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        def is_secure():
+            return True
+        request.is_secure = is_secure
+        return self.get_response(request)

--- a/admin_site/os2borgerpc_admin/settings.py
+++ b/admin_site/os2borgerpc_admin/settings.py
@@ -199,7 +199,7 @@ MIDDLEWARE = (
     "django_otp.middleware.OTPMiddleware",
     "os2borgerpc_admin.middlewares.user_locale_middleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-)
+) + (("os2borgerpc_admin.middlewares.HttpsOnlyMiddleware",) if os.getenv('HTTPS_GUARANTEED') == 'true' else ())
 
 # Email settings
 


### PR DESCRIPTION
Add configuration to trust requests behind proxy

This adds an option that causes Django to trust all requests.
This is useful for cases where the admin-site is running behind a proxy that terminates TLS (such as nginx), thus causing Django to only receive a HTTP (as opposed to HTTPS) request, despite the request originally being HTTPS.
When this option is enabled, HTTP request are treated the same as HTTPS, which they effectively are when running behind a TLS-terminating proxy.
