### PR TITLE
Configure database with environment variables

### DIFF
--- a/admin_site/os2borgerpc_admin/settings.py
+++ b/admin_site/os2borgerpc_admin/settings.py
@@ -83,11 +83,11 @@ SOURCE_DIR = os.path.abspath(os.path.join(install_dir, ".."))
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": settings["DB_NAME"],
-        "USER": settings["DB_USER"],
-        "PASSWORD": settings["DB_PASSWORD"],
-        "HOST": settings["DB_HOST"],
-        "PORT": settings.get("DB_PORT", fallback=""),
+        "NAME": os.environ['DB_NAME'],
+        "USER": os.environ['DB_USER'],
+        "PASSWORD": os.environ['DB_PASSWORD'],
+        "HOST": os.environ['DB_HOST'],
+        "PORT": os.environ['DB_PORT'],
         "OPTIONS": {
             "connect_timeout": 2,  # Minimum in 2
         },

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,6 +18,11 @@ services:
         environment:
             UID: 75030
             GID: 75030
+            DB_HOST: db
+            DB_NAME: bpc
+            DB_USER: bpc
+            DB_PASSWORD: bpc
+            DB_PORT: ""
         user: "${UID}:${GID}"
         build:
             context: .

--- a/dev-environment/dev-settings.ini
+++ b/dev-environment/dev-settings.ini
@@ -12,12 +12,6 @@ SECRET_KEY=v3rys1kr3t
 ADMIN_NAME=OS2borgerPC Admin
 ADMIN_EMAIL=os2borgerpc_admin@os2borgerpc-vendor.example
 
-# Database
-DB_HOST=db
-DB_NAME=bpc
-DB_USER=bpc
-DB_PASSWORD=bpc
-
 # Timezone/Language
 TIME_ZONE=Europe/Copenhagen
 LANGUAGE_CODE=da-dk

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -96,6 +96,11 @@ COPY --from=frontend \
 # set of insecure setting here for only this purpose. We make sure to delete it
 # afterward. If `insecure-settings.ini` is found in any production image,
 # consider it a bug. See `insecure-settings.ini` for a detailed explanation.
+ENV DB_NAME="dummy" \
+    DB_USER="dummy" \
+    DB_PASSWORD="dummy" \
+    DB_HOST="dummy" \
+    DB_PORT="dummy"
 RUN set -ex \
   && BPC_USER_CONFIG_PATH=/code/docker/insecure-settings.ini python ./manage.py collectstatic --no-input --clear \
   && BPC_USER_CONFIG_PATH=/code/docker/insecure-settings.ini python ./manage.py compilemessages \


### PR DESCRIPTION
Configure database with environment variables, instead of with a settings file. This makes it easier to configure.