### PR TITLE
Add HTTP endpoints for cron jobs

### DIFF
--- a/admin_site/os2borgerpc_admin/jobsWsgi.py
+++ b/admin_site/os2borgerpc_admin/jobsWsgi.py
@@ -1,0 +1,43 @@
+"""
+WSGI config for OS2borgerPC admin project.
+
+This module contains a WSGI application to run cron jobs.
+"""
+
+import subprocess
+import uuid
+import logging
+import sys
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+def application(environ, start_response):
+    path = environ.get('PATH_INFO', '/')
+
+    job_routes = {
+        '/jobs/check_notifications': 'check_notifications',
+        '/jobs/clean_up_database': 'clean_up_database',
+    }
+    command = job_routes.get(path, None)
+        
+    if command:
+        error = run(command)
+        if error:
+            trace_id = str(uuid.uuid4())
+            logging.error(f"Error occured (trace ID '{trace_id}')\n{error}")
+            response, status = (f"An internal server error occured. The error has been logged with trace ID '{trace_id}'.", "500 Internal Server Error")
+        else:
+            response, status = ("", "200 OK")
+    else:
+        response, status = "Not found", "404 Not Found"
+
+    start_response(status, [("Content-Type", "text/plain")])
+    return iter([response.encode("utf-8")])
+
+        
+def run(command):
+    try:
+        subprocess.run(['python', 'manage.py', command], check=True, text=True, capture_output=True)
+        return None
+    except subprocess.CalledProcessError as e:
+        return "Internal server error: " + e.stderr.strip() if e.stderr else 'An error occurred without stderr output.'

--- a/compose.yaml
+++ b/compose.yaml
@@ -44,7 +44,8 @@ services:
                    --reload-extra-file /code/admin_site/locale/da/LC_MESSAGES/djangojs.mo
                    --reload-extra-file /code/admin_site/locale/sv/LC_MESSAGES/django.mo
                    --reload-extra-file /code/admin_site/locale/sv/LC_MESSAGES/djangojs.mo
-                   --timeout 0 --config /code/docker/gunicorn-settings.py os2borgerpc_admin.wsgi"
+                   --timeout 0 --config /code/docker/gunicorn-settings.py os2borgerpc_admin.wsgi &
+                   gunicorn --bind 0.0.0.0:8080 os2borgerpc_admin.jobsWsgi"
         volumes:
             - .:/code/
             - ./dev-environment/dev-settings.ini:/user-settings.ini
@@ -54,6 +55,7 @@ services:
             - db
         ports:
             - 9999:9999
+            - 8080:8080
         stdin_open: true
         tty: true
         container_name: bpc_admin_site_django

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,7 +104,7 @@ RUN set -ex \
 # Run the server as the bpc user on port 9999
 USER bpc:bpc
 EXPOSE 9999
+EXPOSE 8080
 ENTRYPOINT ["/code/docker/docker-entrypoint.sh"]
-CMD ["gunicorn", \
-  "--config", "/code/docker/gunicorn-settings.py", \
-  "os2borgerpc_admin.wsgi"]
+CMD bash -c "gunicorn --bind 0.0.0.0:8080 os2borgerpc_admin.jobsWsgi & \
+             gunicorn --config /code/docker/gunicorn-settings.py os2borgerpc_admin.wsgi"


### PR DESCRIPTION
Two endpoints have been created to start cron jobs, which is a solution that is much easier to manage than the current one, which requires an admin-site container to be fully configured and started for each cron job.