### PR TITLE
Fix required inputs error

### DIFF
--- a/admin_site/system/management/commands/fetch_and_install_core_scripts.py
+++ b/admin_site/system/management/commands/fetch_and_install_core_scripts.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
                     tag, created = ScriptTag.objects.get_or_create(name=script.tag)
                     db_script.tags.add(tag)
 
-                    position = 1
+                    position = 0
                     for parameter in script.parameters:
                         Input.objects.create(
                             script=db_script,


### PR DESCRIPTION
The input-parameter position is 0-indexed, not 1, causing false missing parameter messages when users defined Associated Scripts for a Group, despite specifying the parameter correctly.