### PR TITLE
66 konfiguration af pc image download link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,36 @@
+=======================
+OS2borgerPC: Admin-Site
+=======================
+
+This directory contains the OS2borgerPC Admin system, which is a remote
+administration system for Debian-based GNU/Linux-systems, especially
+Ubuntu systems.
+
+The system was originally developed for public libraries in Denmark and
+is specifically designed to manage their OS2borgerPC audience
+desktop PCs.
+
+By design, its functionality aims to be similar to that of Canonical's
+Landscape product, but less ambitious. A special feature is security
+alerts that may be triggered e.g. if a user changes a USB keyboard (some
+libraries have experienced problems with people trying to insert key
+loggers between keyboard and computer).
+
+Read the documentation for this project in docs/ or at
+`Read The Docs <https://os2borgerpc-admin.readthedocs.io/>`_.
+
+The system was developed by Magenta Aps (https://www.magenta.dk) and is part of the
+OS2borgerPC project.
+
+For more information about the OS2borgerPC project, please see the
+official home page:
+
+    https://os2.eu/produkt/os2borgerpc
+
+and the offical Github project:
+
+    https://github.com/OS2borgerPC/
+
+All code is made available under Version 3 of the GNU General Public
+License - see the LICENSE file for details.
+--

--- a/admin_site/os2borgerpc_admin/context_processors.py
+++ b/admin_site/os2borgerpc_admin/context_processors.py
@@ -1,0 +1,10 @@
+from django.conf import settings
+
+def iso_urls(request):
+    """
+    Adds PC and Kiosk ISO URLs to the context for all templates.
+    """
+    return {
+        "pc_image_releases_url": getattr(settings, "PC_IMAGE_RELEASES_URL", ""),
+        "kiosk_image_releases_url": getattr(settings, "KIOSK_IMAGE_RELEASES_URL", ""),
+    }

--- a/admin_site/os2borgerpc_admin/settings.py
+++ b/admin_site/os2borgerpc_admin/settings.py
@@ -24,6 +24,9 @@ ADMINS = (
     else None
 )
 
+PC_IMAGE_RELEASES_URL = os.environ.get("PC_IMAGE_RELEASES_URL")
+KIOSK_IMAGE_RELEASES_URL = os.environ.get("KIOSK_IMAGE_RELEASES_URL")
+
 MANAGERS = ADMINS
 
 # Template settings
@@ -41,6 +44,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                'os2borgerpc_admin.context_processors.iso_urls',
             ],
             "builtins": [
                 "system.templatetags.custom_tags",

--- a/admin_site/system/views.py
+++ b/admin_site/system/views.py
@@ -3934,7 +3934,6 @@ class DocView(TemplateView, LoginRequiredMixin):
 
         return context
 
-
 class ImageVersionRedirect(RedirectView):
     def get_redirect_url(self, **kwargs):
         site = get_object_or_404(Site, uid=kwargs["slug"])

--- a/admin_site/templates/site_with_navigation.html
+++ b/admin_site/templates/site_with_navigation.html
@@ -117,9 +117,31 @@ detailpage
     </a>
 
     {% set_css_class_active request.resolver_match.url_name "images" as current_url_images %}
-    <a class="nav-link link-light {{ current_url_images }}" href="{% url 'images' slug=site.url %}">
-      <span class="material-icons"> cloud_download </span> {% translate "Images" %}
-    </a>
+    <div class="nav-item dropdown">
+      <a 
+          class="nav-link link-light dropdown-toggle" 
+          href="#" 
+          id="imageDropdown" 
+          role="button" 
+          data-bs-toggle="dropdown" 
+          aria-expanded="false"
+      >
+          <span class="material-icons"> cloud_download </span> {% translate "Images" %}
+      </a>
+      <ul class="dropdown-menu" aria-labelledby="imageDropdown">
+          <li>
+              <a class="dropdown-item" href="{{ pc_image_releases_url }}" target="_blank" rel="noopener noreferrer">
+                  PC Image releases
+              </a>
+          </li>
+          <li>
+              <a class="dropdown-item" href="{{ kiosk_image_releases_url }}" target="_blank" rel="noopener noreferrer">
+                  Kiosk Image releases
+              </a>
+          </li>
+      </ul>
+    </div>
+  
     <hr>
 
     <h2 class="text-light">{% translate "Documentation" %}</h2>

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,8 @@ services:
             ALLOWED_HOSTS: "*"
             CORE_SCRIPT_COMMIT_HASH: db319672efdcc0f7402c4a7370aa763be9960c38
             CORE_SCRIPT_VERSION_TAG: v0.1.4
+            PC_IMAGE_RELEASES_URL: https://github.com/OS2borgerPC/os2borgerpc-image/releases
+            KIOSK_IMAGE_RELEASES_URL: https://github.com/OS2borgerPC/os2borgerpc-kiosk-image/releases
             DEBUG: True
             SECRET_KEY: v3rys1kr3t
             # Admin contact - fill in your own name and email as desired.


### PR DESCRIPTION
Images knappen åbner nu to knapper, én for hver image, som linker til releases her på github.