### PR TITLE
add missing dependency, git

### DIFF
--- a/admin_site/sys-requirements.txt
+++ b/admin_site/sys-requirements.txt
@@ -1,2 +1,3 @@
 gettext
 curl
+git


### PR DESCRIPTION
Hej @agnetemoos 

der kom desværre en lille efter behandling.
Der er en dependency, git klienten, som ikke default er med i det nye '-slim' base image.
